### PR TITLE
Remove the Assets.manifest_css method as manifest-css.json is no long…

### DIFF
--- a/CTFd/constants/assets.py
+++ b/CTFd/constants/assets.py
@@ -15,13 +15,6 @@ class _AssetsWrapper:
         )
         return get_asset_json(path=manifest)
 
-    def manifest_css(self):
-        theme = ctf_theme()
-        manifest = os.path.join(
-            current_app.root_path, "themes", theme, "static", "manifest-css.json"
-        )
-        return get_asset_json(path=manifest)
-
     def js(self, asset_key):
         asset = self.manifest()[asset_key]
         entry = asset["file"]
@@ -37,7 +30,7 @@ class _AssetsWrapper:
         return markup(html)
 
     def css(self, asset_key):
-        asset = self.manifest_css()[asset_key]
+        asset = self.manifest()[asset_key]
         entry = asset["file"]
         url = url_for("views.themes_beta", path=entry)
         return markup(f'<link rel="stylesheet" href="{url}">')


### PR DESCRIPTION
…er necessary (#2164)

* Remove the Assets.manifest_css method as manifest-css.json is no longer necessary
* Related to https://github.com/CTFd/core-beta/pull/22